### PR TITLE
override autograb if beam break breaks

### DIFF
--- a/2023-Code/src/main/java/frc/robot/commands/ArmFeederCommand.java
+++ b/2023-Code/src/main/java/frc/robot/commands/ArmFeederCommand.java
@@ -33,7 +33,7 @@ public class ArmFeederCommand extends CommandBase {
     m_pidController = p_pidController;
     m_telescopeSubsystem = p_subsystemContainer.getTelescopeSubsystem();
     m_timer = new Timer();
-    addRequirements(m_armSubsystem, m_scoringSubsystem);
+    addRequirements(m_armSubsystem);
   }
 
   @Override


### PR DESCRIPTION
deletes the subsystem req in the command